### PR TITLE
Use standard rosdep keyname for Eigen3 dependency.

### DIFF
--- a/orocos_kdl/package.xml
+++ b/orocos_kdl/package.xml
@@ -10,9 +10,9 @@
   <license>LGPL</license>
 
   <buildtool_depend>cmake</buildtool_depend>
-  <build_depend>Eigen3</build_depend>
+  <build_depend>eigen3</build_depend>
 
-  <exec_depend>Eigen3</exec_depend>
+  <exec_depend>eigen3</exec_depend>
   <exec_depend>pkg-config</exec_depend>
 
   <test_depend>cppunit</test_depend>

--- a/orocos_kdl/package.xml
+++ b/orocos_kdl/package.xml
@@ -10,9 +10,9 @@
   <license>LGPL</license>
 
   <buildtool_depend>cmake</buildtool_depend>
-  <build_depend>eigen3</build_depend>
+  <build_depend>eigen</build_depend>
 
-  <exec_depend>eigen3</exec_depend>
+  <exec_depend>eigen</exec_depend>
   <exec_depend>pkg-config</exec_depend>
 
   <test_depend>cppunit</test_depend>


### PR DESCRIPTION
`eigen` is the existing key name for Eigen3 in rosdep.

[As seen here](https://github.com/ros/rosdistro/blob/1514c150aeb1bfb3cd05d134abd78af92b460158/rosdep/base.yaml#L542-L557)