### PR TITLE
port python_orocos_kdl to ros2

### DIFF
--- a/python_orocos_kdl/CMakeLists.txt
+++ b/python_orocos_kdl/CMakeLists.txt
@@ -17,7 +17,6 @@ include_directories(${orocos_kdl_INCLUDE_DIRS})
 link_directories(${orocos_kdl_LIBRARY_DIRS})
 
 set(PYTHON_VERSION 3.5 CACHE STRING "Python Version")
-message(STATUS ${PYTHON_VERSION_STRING})
 find_package(PythonInterp ${PYTHON_VERSION} REQUIRED)
 find_package(PythonLibs ${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR} REQUIRED)
 execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(plat_specific=True, prefix=''))" OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE)

--- a/python_orocos_kdl/CMakeLists.txt
+++ b/python_orocos_kdl/CMakeLists.txt
@@ -16,7 +16,7 @@ include_directories(${orocos_kdl_INCLUDE_DIRS})
 link_directories(${orocos_kdl_LIBRARY_DIRS})
 
 SET(PYTHON_VERSION 3.5 CACHE STRING "Python Version")
-message(PYTHON_VERSION_STRING)
+message(STATUS ${PYTHON_VERSION_STRING})
 find_package(PythonInterp ${PYTHON_VERSION} REQUIRED)
 find_package(PythonLibs ${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR} REQUIRED)
 execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(plat_specific=True, prefix=''))" OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE)
@@ -29,9 +29,28 @@ include_directories(${SIP_INCLUDE_DIR} ${PYTHON_INCLUDE_DIRS})
 file(GLOB SIP_FILES "${CMAKE_CURRENT_SOURCE_DIR}/*.sip")
 set(SIP_INCLUDES ${SIP_FILES})
 set(SIP_EXTRA_OPTIONS "-o")
-set(PYTHON_SITE_PACKAGES_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/${PYTHON_SITE_PACKAGES})
+set(PYTHON_INSTALL_DIR ${PYTHON_SITE_PACKAGES})
 add_sip_python_module(PyKDL PyKDL/PyKDL.sip ${orocos_kdl_LIBRARIES})
 
-ament_package()
+# Manually trigger adding install directory to $PYTHONPATH - until ament supports SIP packages or a better solution is found
+configure_file(
+  "cmake/pythonpath_hook.sh.in"
+  "cmake/pythonpath_hook.sh"
+  @ONLY
+)
+ament_environment_hooks(
+  ${CMAKE_CURRENT_BINARY_DIR}/cmake/pythonpath_hook.sh
+)
 
-install(FILES package.xml DESTINATION share/python_orocos_kdl)
+# python_module_PyKDL is target name created by add_sip_python_module()
+install(
+  TARGETS python_module_PyKDL
+  DESTINATION "${CMAKE_INSTALL_PREFIX}/${PYTHON_INSTALL_DIR}"
+)
+
+install(
+	FILES package.xml
+	DESTINATION share/${PROJECT_NAME}
+)
+
+ament_package()

--- a/python_orocos_kdl/CMakeLists.txt
+++ b/python_orocos_kdl/CMakeLists.txt
@@ -11,11 +11,12 @@ endif()
 project(python_orocos_kdl)
 
 find_package(ament_cmake REQUIRED)
-find_package(orocos_kdl)
+find_package(orocos_kdl REQUIRED)
+
 include_directories(${orocos_kdl_INCLUDE_DIRS})
 link_directories(${orocos_kdl_LIBRARY_DIRS})
 
-SET(PYTHON_VERSION 3.5 CACHE STRING "Python Version")
+set(PYTHON_VERSION 3.5 CACHE STRING "Python Version")
 message(STATUS ${PYTHON_VERSION_STRING})
 find_package(PythonInterp ${PYTHON_VERSION} REQUIRED)
 find_package(PythonLibs ${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR} REQUIRED)
@@ -49,8 +50,25 @@ install(
 )
 
 install(
-	FILES package.xml
-	DESTINATION share/${PROJECT_NAME}
+  FILES package.xml
+  DESTINATION share/${PROJECT_NAME}
 )
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_pytest REQUIRED)
+
+  ament_add_pytest_test(
+    Frames
+    tests/framestest.py
+  )
+  ament_add_pytest_test(
+    FrameVel
+    tests/frameveltest.py
+  )
+  ament_add_pytest_test(
+    KinematicFamily
+    tests/framestest.py
+  )
+endif()
 
 ament_package()

--- a/python_orocos_kdl/CMakeLists.txt
+++ b/python_orocos_kdl/CMakeLists.txt
@@ -60,14 +60,17 @@ if(BUILD_TESTING)
   ament_add_pytest_test(
     Frames
     tests/framestest.py
+    APPEND_ENV PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}
   )
   ament_add_pytest_test(
     FrameVel
     tests/frameveltest.py
+    APPEND_ENV PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}
   )
   ament_add_pytest_test(
     KinematicFamily
     tests/framestest.py
+    APPEND_ENV PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}
   )
 endif()
 

--- a/python_orocos_kdl/CMakeLists.txt
+++ b/python_orocos_kdl/CMakeLists.txt
@@ -1,12 +1,22 @@
-cmake_minimum_required(VERSION 2.4.6)
+cmake_minimum_required(VERSION 3.5)
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
 
 project(python_orocos_kdl)
 
+find_package(ament_cmake REQUIRED)
 find_package(orocos_kdl)
 include_directories(${orocos_kdl_INCLUDE_DIRS})
 link_directories(${orocos_kdl_LIBRARY_DIRS})
 
-SET(PYTHON_VERSION 2 CACHE STRING "Python Version")
+SET(PYTHON_VERSION 3.5 CACHE STRING "Python Version")
+message(PYTHON_VERSION_STRING)
 find_package(PythonInterp ${PYTHON_VERSION} REQUIRED)
 find_package(PythonLibs ${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR} REQUIRED)
 execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(plat_specific=True, prefix=''))" OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE)
@@ -21,5 +31,7 @@ set(SIP_INCLUDES ${SIP_FILES})
 set(SIP_EXTRA_OPTIONS "-o")
 set(PYTHON_SITE_PACKAGES_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/${PYTHON_SITE_PACKAGES})
 add_sip_python_module(PyKDL PyKDL/PyKDL.sip ${orocos_kdl_LIBRARIES})
+
+ament_package()
 
 install(FILES package.xml DESTINATION share/python_orocos_kdl)

--- a/python_orocos_kdl/PyKDL/std_string.sip
+++ b/python_orocos_kdl/PyKDL/std_string.sip
@@ -49,7 +49,11 @@
      }
      if (PyUnicode_Check(sipPy)) {
         PyObject* s = PyUnicode_AsEncodedString(sipPy, "UTF-8", "");
+#if PY_MAJOR_VERSION < 3
         *sipCppPtr = new std::string(PyUnicode_AS_DATA(s));
+#else
+        *sipCppPtr = new std::string(PyBytes_AS_STRING(s));
+#endif
         Py_DECREF(s);
         return 1;
      }
@@ -63,4 +67,3 @@
      return 0;
 %End
 };
-

--- a/python_orocos_kdl/cmake/FindSIP.cmake
+++ b/python_orocos_kdl/cmake/FindSIP.cmake
@@ -33,6 +33,7 @@ ELSE(SIP_VERSION)
 
   FIND_FILE(_find_sip_py FindSIP.py PATHS ${CMAKE_MODULE_PATH} NO_CMAKE_FIND_ROOT_PATH)
 
+  MESSAGE(STATUS "Checking for SIP using Python: ${PYTHON_EXECUTABLE}")
   EXECUTE_PROCESS(COMMAND ${PYTHON_EXECUTABLE} ${_find_sip_py} OUTPUT_VARIABLE sip_config)
   IF(sip_config)
     STRING(REGEX REPLACE "^sip_version:([^\n]+).*$" "\\1" SIP_VERSION ${sip_config})

--- a/python_orocos_kdl/cmake/SIPMacros.cmake
+++ b/python_orocos_kdl/cmake/SIPMacros.cmake
@@ -103,9 +103,9 @@ MACRO(ADD_SIP_PYTHON_MODULE MODULE_NAME MODULE_SIP)
         ENDFOREACH(filename ${_sip_output_files})
     ENDIF(NOT WIN32)
     ADD_CUSTOM_COMMAND(
-        OUTPUT ${_sip_output_files} 
+        OUTPUT ${_sip_output_files}
         COMMAND ${CMAKE_COMMAND} -E echo ${message}
-        COMMAND ${TOUCH_COMMAND} ${_sip_output_files} 
+        COMMAND ${TOUCH_COMMAND} ${_sip_output_files}
         COMMAND ${SIP_EXECUTABLE} ${_sip_tags} ${_sip_x} ${SIP_EXTRA_OPTIONS} -j ${SIP_CONCAT_PARTS} -c ${CMAKE_CURRENT_SIP_OUTPUT_DIR} ${_sip_includes} ${_abs_module_sip}
         DEPENDS ${_abs_module_sip} ${SIP_EXTRA_FILES_DEPEND}
     )
@@ -119,6 +119,7 @@ MACRO(ADD_SIP_PYTHON_MODULE MODULE_NAME MODULE_SIP)
     TARGET_LINK_LIBRARIES(${_logical_name} ${EXTRA_LINK_LIBRARIES})
     SET_TARGET_PROPERTIES(${_logical_name} PROPERTIES PREFIX "" OUTPUT_NAME ${_child_module_name})
 
-    INSTALL(TARGETS ${_logical_name} DESTINATION "${PYTHON_SITE_PACKAGES_INSTALL_DIR}/${_parent_module_path}")
+    # install step moved into main CMakeLists.txt with better destination
+    # INSTALL(TARGETS ${_logical_name} DESTINATION "${PYTHON_SITE_PACKAGES_INSTALL_DIR}/${_parent_module_path}")
 
 ENDMACRO(ADD_SIP_PYTHON_MODULE)

--- a/python_orocos_kdl/cmake/pythonpath_hook.sh.in
+++ b/python_orocos_kdl/cmake/pythonpath_hook.sh.in
@@ -1,0 +1,4 @@
+# copy of ament_package/template/environment_hook/pythonpath.sh.in
+# https://github.com/ament/ament_package/blob/master/ament_package/template/environment_hook/pythonpath.sh.in
+
+ament_prepend_unique_value PYTHONPATH "$AMENT_CURRENT_PREFIX/@PYTHON_INSTALL_DIR@"

--- a/python_orocos_kdl/package.xml
+++ b/python_orocos_kdl/package.xml
@@ -19,6 +19,9 @@
   <exec_depend>python3-sip</exec_depend>
   <exec_depend>python3</exec_depend>
 
+  <test_depend>ament_cmake</test_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/python_orocos_kdl/package.xml
+++ b/python_orocos_kdl/package.xml
@@ -3,22 +3,24 @@
   <version>1.4.0</version>
   <description>
     This package contains the python bindings PyKDL for the Kinematics and Dynamics
-    Library (KDL), distributed by the Orocos Project. 
+    Library (KDL), distributed by the Orocos Project.
   </description>
   <maintainer email="ruben@intermodalics.eu">Ruben Smits</maintainer>
   <url>http://wiki.ros.org/python_orocos_kdl</url>
   <license>LGPL</license>
 
-  <buildtool_depend>cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
   <build_depend>orocos_kdl</build_depend>
-  <build_depend>python-sip</build_depend>
+  <build_depend>python3-sip</build_depend>
+  <build_depend>python3</build_depend>
 
   <exec_depend>orocos_kdl</exec_depend>
-  <exec_depend>python-sip</exec_depend>
+  <exec_depend>python3-sip</exec_depend>
+  <exec_depend>python3</exec_depend>
 
   <export>
-    <build_type>cmake</build_type>
+    <build_type>ament_cmake</build_type>
   </export>
 
 </package>

--- a/python_orocos_kdl/tests/PyKDLtest.py
+++ b/python_orocos_kdl/tests/PyKDLtest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # Copyright  (C)  2007  Ruben Smits <ruben dot smits at mech dot kuleuven dot be>
 
 # Version: 1.0
@@ -19,6 +19,7 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 import unittest
 import kinfamtest
 import framestest

--- a/python_orocos_kdl/tests/framestest.py
+++ b/python_orocos_kdl/tests/framestest.py
@@ -23,10 +23,10 @@
 import unittest
 from PyKDL import *
 from math import *
-    
+
 class FramesTestFunctions(unittest.TestCase):
 
-    def testVector2(self,v):
+    def _testVector2(self,v):
         self.assertEqual(2*v-v,v)
         self.assertEqual(v*2-v,v)
         self.assertEqual(v+v+v-2*v,v)
@@ -41,123 +41,123 @@ class FramesTestFunctions(unittest.TestCase):
 
     def testVector(self):
         v=Vector(3,4,5)
-        self.testVector2(v)
+        self._testVector2(v)
         v=Vector.Zero()
-        self.testVector2(v)
-    
-    def testTwist2(self,t):
+        self._testVector2(v)
+
+    def _testTwist2(self,t):
         self.assertEqual(2*t-t,t)
-	self.assertEqual(t*2-t,t)
-	self.assertEqual(t+t+t-2*t,t)
-	t2=Twist(t)
-	self.assertEqual(t,t2)
-	t2+=t
-	self.assertEqual(2*t,t2)
-	t2-=t
-	self.assertEqual(t,t2)
-	t.ReverseSign()
-	self.assertEqual(t,-t2)
+        self.assertEqual(t*2-t,t)
+        self.assertEqual(t+t+t-2*t,t)
+        t2=Twist(t)
+        self.assertEqual(t,t2)
+        t2+=t
+        self.assertEqual(2*t,t2)
+        t2-=t
+        self.assertEqual(t,t2)
+        t.ReverseSign()
+        self.assertEqual(t,-t2)
 
     def testTwist(self):
         t=Twist(Vector(6,3,5),Vector(4,-2,7))
-        self.testTwist2(t)
+        self._testTwist2(t)
         t=Twist.Zero()
-        self.testTwist2(t)
+        self._testTwist2(t)
         t=Twist(Vector(0,-9,-3),Vector(1,-2,-4))
 
-    def testWrench2(self,w):
+    def _testWrench2(self,w):
         self.assertEqual(2*w-w,w)
-	self.assertEqual(w*2-w,w)
-	self.assertEqual(w+w+w-2*w,w)
-	w2=Wrench(w)
-	self.assertEqual(w,w2)
-	w2+=w
-	self.assertEqual(2*w,w2)
-	w2-=w
-	self.assertEqual(w,w2)
-	w.ReverseSign()
-	self.assertEqual(w,-w2)
+        self.assertEqual(w*2-w,w)
+        self.assertEqual(w+w+w-2*w,w)
+        w2=Wrench(w)
+        self.assertEqual(w,w2)
+        w2+=w
+        self.assertEqual(2*w,w2)
+        w2-=w
+        self.assertEqual(w,w2)
+        w.ReverseSign()
+        self.assertEqual(w,-w2)
 
     def testWrench(self):
         w=Wrench(Vector(7,-1,3),Vector(2,-3,3))
-	self.testWrench2(w)
-	w=Wrench.Zero()
-	self.testWrench2(w)
+        self._testWrench2(w)
+        w=Wrench.Zero()
+        self._testWrench2(w)
         w=Wrench(Vector(2,1,4),Vector(5,3,1))
-	self.testWrench2(w)	
+        self._testWrench2(w)
 
-    def testRotation2(self,v,a,b,c):
-	w=Wrench(Vector(7,-1,3),Vector(2,-3,3))
-	t=Twist(Vector(6,3,5),Vector(4,-2,7))
+    def _testRotation2(self,v,a,b,c):
+        w=Wrench(Vector(7,-1,3),Vector(2,-3,3))
+        t=Twist(Vector(6,3,5),Vector(4,-2,7))
         R=Rotation.RPY(a,b,c)
-        
+
         self.assertAlmostEqual(dot(R.UnitX(),R.UnitX()),1.0,15)
-	self.assertEqual(dot(R.UnitY(),R.UnitY()),1.0)
-	self.assertEqual(dot(R.UnitZ(),R.UnitZ()),1.0)
-	self.assertAlmostEqual(dot(R.UnitX(),R.UnitY()),0.0,15)
-	self.assertAlmostEqual(dot(R.UnitX(),R.UnitZ()),0.0,15)
-	self.assertEqual(dot(R.UnitY(),R.UnitZ()),0.0)
-	R2=Rotation(R)
-	self.assertEqual(R,R2)
-	self.assertAlmostEqual((R*v).Norm(),v.Norm(),14)
-	self.assertEqual(R.Inverse(R*v),v)
-	self.assertEqual(R.Inverse(R*t),t)
-	self.assertEqual(R.Inverse(R*w),w)
-	self.assertEqual(R*R.Inverse(v),v)
-	self.assertEqual(R*Rotation.Identity(),R)
-	self.assertEqual(Rotation.Identity()*R,R)
-	self.assertEqual(R*(R*(R*v)),(R*R*R)*v)
-	self.assertEqual(R*(R*(R*t)),(R*R*R)*t)
-	self.assertEqual(R*(R*(R*w)),(R*R*R)*w)
-	self.assertEqual(R*R.Inverse(),Rotation.Identity())
-	self.assertEqual(R.Inverse()*R,Rotation.Identity())
-	self.assertEqual(R.Inverse()*v,R.Inverse(v))
-	(ra,rb,rc)=R.GetRPY()
-	self.assertEqual(ra,a)
+        self.assertEqual(dot(R.UnitY(),R.UnitY()),1.0)
+        self.assertEqual(dot(R.UnitZ(),R.UnitZ()),1.0)
+        self.assertAlmostEqual(dot(R.UnitX(),R.UnitY()),0.0,15)
+        self.assertAlmostEqual(dot(R.UnitX(),R.UnitZ()),0.0,15)
+        self.assertEqual(dot(R.UnitY(),R.UnitZ()),0.0)
+        R2=Rotation(R)
+        self.assertEqual(R,R2)
+        self.assertAlmostEqual((R*v).Norm(),v.Norm(),14)
+        self.assertEqual(R.Inverse(R*v),v)
+        self.assertEqual(R.Inverse(R*t),t)
+        self.assertEqual(R.Inverse(R*w),w)
+        self.assertEqual(R*R.Inverse(v),v)
+        self.assertEqual(R*Rotation.Identity(),R)
+        self.assertEqual(Rotation.Identity()*R,R)
+        self.assertEqual(R*(R*(R*v)),(R*R*R)*v)
+        self.assertEqual(R*(R*(R*t)),(R*R*R)*t)
+        self.assertEqual(R*(R*(R*w)),(R*R*R)*w)
+        self.assertEqual(R*R.Inverse(),Rotation.Identity())
+        self.assertEqual(R.Inverse()*R,Rotation.Identity())
+        self.assertEqual(R.Inverse()*v,R.Inverse(v))
+        (ra,rb,rc)=R.GetRPY()
+        self.assertEqual(ra,a)
         self.assertEqual(rb,b)
         self.assertEqual(rc,c)
-	R = Rotation.EulerZYX(a,b,c)
-	(ra,rb,rc)=R.GetEulerZYX()
-	self.assertEqual(ra,a)
+        R = Rotation.EulerZYX(a,b,c)
+        (ra,rb,rc)=R.GetEulerZYX()
+        self.assertEqual(ra,a)
         self.assertEqual(rb,b)
         self.assertEqual(rc,c)
-	R = Rotation.EulerZYZ(a,b,c)
-	(ra,rb,rc)=R.GetEulerZYZ()
-	self.assertEqual(ra,a)
+        R = Rotation.EulerZYZ(a,b,c)
+        (ra,rb,rc)=R.GetEulerZYZ()
+        self.assertEqual(ra,a)
         self.assertEqual(rb,b)
         self.assertAlmostEqual(rc,c,15)
-	(angle,v2)= R.GetRotAngle()
-	R2=Rotation.Rot(v2,angle)
-	self.assertEqual(R2,R)
-	R2=Rotation.Rot(v2*1E20,angle)
-	self.assertEqual(R,R2)
-	v2=Vector(6,2,4)
-	self.assertAlmostEqual(v2.Norm(),sqrt(dot(v2,v2)),14)
-    
+        (angle,v2)= R.GetRotAngle()
+        R2=Rotation.Rot(v2,angle)
+        self.assertEqual(R2,R)
+        R2=Rotation.Rot(v2*1E20,angle)
+        self.assertEqual(R,R2)
+        v2=Vector(6,2,4)
+        self.assertAlmostEqual(v2.Norm(),sqrt(dot(v2,v2)),14)
+
     def testRotation(self):
-        self.testRotation2(Vector(3,4,5),radians(10),radians(20),radians(30))
-    
+        self._testRotation2(Vector(3,4,5),radians(10),radians(20),radians(30))
+
     def testFrame(self):
-        v=Vector(3,4,5) 
-	w=Wrench(Vector(7,-1,3),Vector(2,-3,3))
-	t=Twist(Vector(6,3,5),Vector(4,-2,7))
-	F = Frame(Rotation.EulerZYX(radians(10),radians(20),radians(-10)),Vector(4,-2,1))
-	F2=Frame(F)
-	self.assertEqual(F,F2)
-	self.assertEqual(F.Inverse(F*v),v)
-	self.assertEqual(F.Inverse(F*t),t)
-	self.assertEqual(F.Inverse(F*w),w)
-	self.assertEqual(F*F.Inverse(v),v)
-	self.assertEqual(F*F.Inverse(t),t)
-	self.assertEqual(F*F.Inverse(w),w)
-	self.assertEqual(F*Frame.Identity(),F)
-	self.assertEqual(Frame.Identity()*F,F)
-	self.assertEqual(F*(F*(F*v)),(F*F*F)*v)
-	self.assertEqual(F*(F*(F*t)),(F*F*F)*t)
-	self.assertEqual(F*(F*(F*w)),(F*F*F)*w)
-	self.assertEqual(F*F.Inverse(),Frame.Identity())
-	self.assertEqual(F.Inverse()*F,Frame.Identity())
-	self.assertEqual(F.Inverse()*v,F.Inverse(v))
+        v=Vector(3,4,5)
+        w=Wrench(Vector(7,-1,3),Vector(2,-3,3))
+        t=Twist(Vector(6,3,5),Vector(4,-2,7))
+        F = Frame(Rotation.EulerZYX(radians(10),radians(20),radians(-10)),Vector(4,-2,1))
+        F2=Frame(F)
+        self.assertEqual(F,F2)
+        self.assertEqual(F.Inverse(F*v),v)
+        self.assertEqual(F.Inverse(F*t),t)
+        self.assertEqual(F.Inverse(F*w),w)
+        self.assertEqual(F*F.Inverse(v),v)
+        self.assertEqual(F*F.Inverse(t),t)
+        self.assertEqual(F*F.Inverse(w),w)
+        self.assertEqual(F*Frame.Identity(),F)
+        self.assertEqual(Frame.Identity()*F,F)
+        self.assertEqual(F*(F*(F*v)),(F*F*F)*v)
+        self.assertEqual(F*(F*(F*t)),(F*F*F)*t)
+        self.assertEqual(F*(F*(F*w)),(F*F*F)*w)
+        self.assertEqual(F*F.Inverse(),Frame.Identity())
+        self.assertEqual(F.Inverse()*F,Frame.Identity())
+        self.assertEqual(F.Inverse()*v,F.Inverse(v))
 
     def testPickle(self):
         import pickle
@@ -167,15 +167,15 @@ class FramesTestFunctions(unittest.TestCase):
         data['fr'] = Frame(data['rot'], data['v'])
         data['tw'] = Twist(data['v'], Vector(4,5,6))
         data['wr'] = Wrench(Vector(0.1,0.2,0.3), data['v'])
-        
-        f = open('/tmp/pickle_test', 'w')
+
+        f = open('/tmp/pickle_test', 'wb')
         pickle.dump(data, f)
         f.close()
-        
-        f = open('/tmp/pickle_test', 'r')
+
+        f = open('/tmp/pickle_test', 'rb')
         data1 = pickle.load(f)
         f.close()
-       
+
         self.assertEqual(data, data1)
 
 
@@ -188,6 +188,6 @@ def suite():
     suite.addTest(FramesTestFunctions('testFrame'))
     suite.addTest(FramesTestFunctions('testPickle'))
     return suite
-    
+
 #suite = suite()
 #unittest.TextTestRunner(verbosity=3).run(suite)

--- a/python_orocos_kdl/tests/frameveltest.py
+++ b/python_orocos_kdl/tests/frameveltest.py
@@ -5,65 +5,65 @@ from math import *
 class FrameVelTestFunctions(unittest.TestCase):
 
     def testVectorVel(self):
-	v=VectorVel(Vector(3,-4,5),Vector(6,3,-5))
-	vt = Vector(-4,-6,-8);
-	self.assert_(Equal( 2*v-v,v))
-	self.assert_(Equal( v*2-v,v))
-	self.assert_(Equal( v+v+v-2*v,v))
-	v2=VectorVel(v)
-	self.assert_(Equal( v,v2))
-	v2+=v
-	self.assert_(Equal( 2*v,v2))
-	v2-=v
-	self.assert_(Equal( v,v2))
-	v2.ReverseSign()
-	self.assert_(Equal( v,-v2))
-	self.assert_(Equal( v*vt,-vt*v))
-	v2 = VectorVel(Vector(-5,-6,-3),Vector(3,4,5))
-	self.assert_(Equal( v*v2,-v2*v))
+        v=VectorVel(Vector(3,-4,5),Vector(6,3,-5))
+        vt = Vector(-4,-6,-8);
+        self.assert_(Equal( 2*v-v,v))
+        self.assert_(Equal( v*2-v,v))
+        self.assert_(Equal( v+v+v-2*v,v))
+        v2=VectorVel(v)
+        self.assert_(Equal( v,v2))
+        v2+=v
+        self.assert_(Equal( 2*v,v2))
+        v2-=v
+        self.assert_(Equal( v,v2))
+        v2.ReverseSign()
+        self.assert_(Equal( v,-v2))
+        self.assert_(Equal( v*vt,-vt*v))
+        v2 = VectorVel(Vector(-5,-6,-3),Vector(3,4,5))
+        self.assert_(Equal( v*v2,-v2*v))
 
-       
+
     def testRotationVel(self):
         v=VectorVel(Vector(9,4,-2),Vector(-5,6,-2))
-	vt=Vector(2,3,4)
-	a= radians(-15)
-	b= radians(20)
-	c= radians(-80)
-	R = RotationVel(Rotation.RPY(a,b,c),Vector(2,4,1))
-	R2=RotationVel(R)	
-	self.assert_(Equal(R,R2))
-	self.assert_(Equal((R*v).Norm(),(v.Norm())))
-	self.assert_(Equal(R.Inverse(R*v),v))
-	self.assert_(Equal(R*R.Inverse(v),v))
-	self.assert_(Equal(R*Rotation.Identity(),R))
-	self.assert_(Equal(Rotation.Identity()*R,R))
-	self.assert_(Equal(R*(R*(R*v)),(R*R*R)*v))
-	self.assert_(Equal(R*(R*(R*vt)),(R*R*R)*vt))
-	self.assert_(Equal(R*R.Inverse(),RotationVel.Identity()))
-	self.assert_(Equal(R.Inverse()*R,RotationVel.Identity()))
-	self.assert_(Equal(R.Inverse()*v,R.Inverse(v)))
-	#v2=v*v-2*v
+        vt=Vector(2,3,4)
+        a= radians(-15)
+        b= radians(20)
+        c= radians(-80)
+        R = RotationVel(Rotation.RPY(a,b,c),Vector(2,4,1))
+        R2=RotationVel(R)
+        self.assert_(Equal(R,R2))
+        self.assert_(Equal((R*v).Norm(),(v.Norm())))
+        self.assert_(Equal(R.Inverse(R*v),v))
+        self.assert_(Equal(R*R.Inverse(v),v))
+        self.assert_(Equal(R*Rotation.Identity(),R))
+        self.assert_(Equal(Rotation.Identity()*R,R))
+        self.assert_(Equal(R*(R*(R*v)),(R*R*R)*v))
+        self.assert_(Equal(R*(R*(R*vt)),(R*R*R)*vt))
+        self.assert_(Equal(R*R.Inverse(),RotationVel.Identity()))
+        self.assert_(Equal(R.Inverse()*R,RotationVel.Identity()))
+        self.assert_(Equal(R.Inverse()*v,R.Inverse(v)))
+        #v2=v*v-2*v
         #print dot(v2,v2)
-	#self.assert_(Equal((v2).Norm(),sqrt(dot(v2,v2))))
+        #self.assert_(Equal((v2).Norm(),sqrt(dot(v2,v2))))
 
     def testFrameVel(self):
-	v=VectorVel(Vector(3,4,5),Vector(-2,-4,-1))
-	vt=Vector(-1,0,-10)
-	F = FrameVel(Frame(Rotation.EulerZYX(radians(10),radians(20),radians(-10)),Vector(4,-2,1)),
-                     Twist(Vector(2,-2,-2),Vector(-5,-3,-2)))					
-	F2=FrameVel(F)
-	self.assert_(Equal( F,F2))
-	self.assert_(Equal( F.Inverse(F*v),v))
-	self.assert_(Equal( F.Inverse(F*vt), vt))
-	self.assert_(Equal( F*F.Inverse(v),v))
-	self.assert_(Equal( F*F.Inverse(vt),vt))
-	self.assert_(Equal( F*Frame.Identity(),F))
-	self.assert_(Equal( Frame.Identity()*F,F))
-	self.assert_(Equal( F*(F*(F*v)),(F*F*F)*v))
-	self.assert_(Equal( F*(F*(F*vt)),(F*F*F)*vt))
-	self.assert_(Equal( F*F.Inverse(),FrameVel.Identity()))
-	self.assert_(Equal( F.Inverse()*F,Frame.Identity()))
-	self.assert_(Equal( F.Inverse()*vt,F.Inverse(vt)))
+        v=VectorVel(Vector(3,4,5),Vector(-2,-4,-1))
+        vt=Vector(-1,0,-10)
+        F = FrameVel(Frame(Rotation.EulerZYX(radians(10),radians(20),radians(-10)),Vector(4,-2,1)),
+                     Twist(Vector(2,-2,-2),Vector(-5,-3,-2)))
+        F2=FrameVel(F)
+        self.assert_(Equal( F,F2))
+        self.assert_(Equal( F.Inverse(F*v),v))
+        self.assert_(Equal( F.Inverse(F*vt), vt))
+        self.assert_(Equal( F*F.Inverse(v),v))
+        self.assert_(Equal( F*F.Inverse(vt),vt))
+        self.assert_(Equal( F*Frame.Identity(),F))
+        self.assert_(Equal( Frame.Identity()*F,F))
+        self.assert_(Equal( F*(F*(F*v)),(F*F*F)*v))
+        self.assert_(Equal( F*(F*(F*vt)),(F*F*F)*vt))
+        self.assert_(Equal( F*F.Inverse(),FrameVel.Identity()))
+        self.assert_(Equal( F.Inverse()*F,Frame.Identity()))
+        self.assert_(Equal( F.Inverse()*vt,F.Inverse(vt)))
 
 
     def testPickle(self):
@@ -74,15 +74,15 @@ class FrameVelTestFunctions(unittest.TestCase):
         data['rv'] = RotationVel(rot, Vector(4.1,5.1,6.1))
         data['fv'] = FrameVel(data['rv'], data['vv'])
         data['tv'] = TwistVel(data['vv'], data['vv'])
-        
-        f = open('/tmp/pickle_test_kdl_framevel', 'w')
+
+        f = open('/tmp/pickle_test_kdl_framevel', 'wb')
         pickle.dump(data, f)
         f.close()
-        
-        f = open('/tmp/pickle_test_kdl_framevel', 'r')
+
+        f = open('/tmp/pickle_test_kdl_framevel', 'rb')
         data1 = pickle.load(f)
         f.close()
-       
+
         self.assertEqual(data['vv'].p, data1['vv'].p)
         self.assertEqual(data['vv'].v, data1['vv'].v)
         self.assertEqual(data['rv'].R, data1['rv'].R)
@@ -151,7 +151,7 @@ class FrameVelTestFunctions(unittest.TestCase):
 #	TwistAcc     t( VectorAcc(Vector(6,3,5),Vector(1,4,2),Vector(5,2,1)),
 #		              VectorAcc(Vector(4,-2,7),Vector(-1,-2,-3),Vector(5,2,9) )
 #					);
-#	TwistAcc    t2; 
+#	TwistAcc    t2;
 #	RotationAcc  R(Rotation::RPY(10*deg2rad,20*deg2rad,-15*deg2rad),
 #		             Vector(-1,5,3),
 #					 Vector(2,1,3)
@@ -160,12 +160,12 @@ class FrameVelTestFunctions(unittest.TestCase):
 #			Frame(Rotation::EulerZYX(-17*deg2rad,13*deg2rad,-16*deg2rad),Vector(4,-2,1)),
 #			Twist(Vector(2,-2,-2),Vector(-5,-3,-2)),
 #			Twist(Vector(5,4,-5),Vector(12,13,17))
-#		    );	
+#		    );
 #
 #	KDL_DIFF(2.0*t-t,t);
 #	KDL_DIFF(t*2.0-t,t);
 #	KDL_DIFF(t+t+t-2.0*t,t);
-#	t2=t; 
+#	t2=t;
 #	KDL_DIFF(t,t2);
 #	t2+=t;
 #	KDL_DIFF(2.0*t,t2);

--- a/python_orocos_kdl/tests/kinfamtest.py
+++ b/python_orocos_kdl/tests/kinfamtest.py
@@ -26,18 +26,18 @@ from math import *
 import random
 
 class KinfamTestFunctions(unittest.TestCase):
-    
+
     def setUp(self):
         self.chain = Chain()
         self.chain.addSegment(Segment(Joint(Joint.RotZ),
                                  Frame(Vector(0.0,0.0,0.0))))
         self.chain.addSegment(Segment(Joint(Joint.RotX),
                                  Frame(Vector(0.0,0.0,0.9))))
-        self.chain.addSegment(Segment(Joint(Joint.None),
+        self.chain.addSegment(Segment(Joint(),
                                  Frame(Vector(-0.4,0.0,0.0))))
         self.chain.addSegment(Segment(Joint(Joint.RotY),
                              Frame(Vector(0.0,0.0,1.2))))
-        self.chain.addSegment(Segment(Joint(Joint.None),
+        self.chain.addSegment(Segment(Joint(),
                                  Frame(Vector(0.4,0.0,0.0))))
         self.chain.addSegment(Segment(Joint(Joint.TransZ),
                                  Frame(Vector(0.0,0.0,1.4))))
@@ -45,7 +45,7 @@ class KinfamTestFunctions(unittest.TestCase):
                                  Frame(Vector(0.0,0.0,0.0))))
         self.chain.addSegment(Segment(Joint(Joint.TransY),
                                  Frame(Vector(0.0,0.0,0.4))))
-        self.chain.addSegment(Segment(Joint(Joint.None),
+        self.chain.addSegment(Segment(Joint(),
                                  Frame(Vector(0.0,0.0,0.0))))
 
         self.jacsolver   = ChainJntToJacSolver(self.chain)
@@ -63,12 +63,12 @@ class KinfamTestFunctions(unittest.TestCase):
 
         q=JntArray(self.chain.getNrOfJoints())
         jac=Jacobian(self.chain.getNrOfJoints())
-        
+
         for i in range(q.rows()):
             q[i]=random.uniform(-3.14,3.14)
 
         self.jacsolver.JntToJac(q,jac)
-        
+
         for i in range(q.rows()):
             oldqi=q[i];
             q[i]=oldqi+deltaq
@@ -84,7 +84,7 @@ class KinfamTestFunctions(unittest.TestCase):
     def testFkVelAndJac(self):
         deltaq = 1E-4
         epsJ   = 1E-4
-    
+
         q=JntArray(self.chain.getNrOfJoints())
         qdot=JntArray(self.chain.getNrOfJoints())
         for i in range(q.rows()):
@@ -113,37 +113,37 @@ class KinfamTestFunctions(unittest.TestCase):
 
         qvel=JntArrayVel(q,qdot)
         qdot_solved=JntArray(self.chain.getNrOfJoints())
-        
+
         cart = FrameVel()
-        
+
         self.assert_(0==self.fksolvervel.JntToCart(qvel,cart))
         self.assert_(0==self.iksolvervel.CartToJnt(qvel.q,cart.deriv(),qdot_solved))
-        
+
         self.assertEqual(qvel.qdot,qdot_solved);
-        
+
 
     def testFkPosAndIkPos(self):
         q=JntArray(self.chain.getNrOfJoints())
         for i in range(q.rows()):
             q[i]=random.uniform(-3.14,3.14)
-        
+
         q_init=JntArray(self.chain.getNrOfJoints())
         for i in range(q_init.rows()):
             q_init[i]=q[i]+0.1*random.random()
-            
+
         q_solved=JntArray(q.rows())
 
         F1=Frame.Identity()
         F2=Frame.Identity()
-    
+
         self.assert_(0==self.fksolverpos.JntToCart(q,F1))
         self.assert_(0==self.iksolverpos.CartToJnt(q_init,F1,q_solved))
         self.assert_(0==self.fksolverpos.JntToCart(q_solved,F2))
-        
+
         self.assertEqual(F1,F2)
         self.assertEqual(q,q_solved)
-        
-        
+
+
 def suite():
     suite = unittest.TestSuite()
     suite.addTest(KinfamTestFunctions('testFkPosAndJac'))
@@ -154,4 +154,4 @@ def suite():
 
 #suite = suite()
 #unittest.TextTestRunner(verbosity=3).run(suite)
-            
+


### PR DESCRIPTION
This PR enables PyKDL usage in ROS2.

Fixes in SIP are by @rkojcev and @vmayoral, so is basic adaptation of `package.xml` and `CMakeLists.txt` to ament, I've additionally added triggering `PYTHONPATH` hook (as ament does not support SIP packages yet) and improved installation of compiled objects.