### PR TITLE
ignore deprecation warnings on linux

### DIFF
--- a/orocos_kdl/CMakeLists.txt
+++ b/orocos_kdl/CMakeLists.txt
@@ -93,13 +93,18 @@ ENDIF(ENABLE_TESTS )
 
 # Disable Windows Compiler warnings
 # see https://msdn.microsoft.com/en-us/library/thxezb7y.aspx
-IF(WIN32)
+IF(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   add_definitions(
     "/W3"
     "/wd4244"
     "/wd4267"
     "/wd4800"
     "/wd4996")
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+  # https://github.com/orocos/orocos_kinematics_dynamics/issues/104
+  add_definitions(
+    "-Wno-deprecated-declarations"
+  )
 endif()
 
 OPTION(ENABLE_EXAMPLES OFF "Enable building of examples")


### PR DESCRIPTION
orocos_kdl has now a handful of deprecation warnings in newer GCCs.
http://build.ros.org/view/Mdev/job/Mdev__orocos_kinematics_dynamics__ubuntu_bionic_amd64/1/warnings22Result/
https://ci.ros2.org/job/ci_linux/4235/warnings23Result/

As this has been [ticketed upstream](https://github.com/orocos/orocos_kinematics_dynamics/issues/104), I'd rather not fix it in the ROS2 fork but pull it from the upstream repo when it gets fixed there.

This PR ignores these warnings for now
Job with that branch: https://ci.ros2.org/job/ci_linux/4249/

Connects to ros2/ros2#481
