### PR TITLE
level version of all packages to 3.0.0

### DIFF
--- a/orocos_kinematics_dynamics/package.xml
+++ b/orocos_kinematics_dynamics/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>orocos_kinematics_dynamics</name>
-  <version>1.3.1</version>
+  <version>3.0.0</version>
   <description>
     This package depends on a recent version of the Kinematics and Dynamics
     Library (KDL), distributed by the Orocos Project. It is a meta-package that

--- a/python_orocos_kdl/package.xml
+++ b/python_orocos_kdl/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>python_orocos_kdl</name>
-  <version>1.4.0</version>
+  <version>3.0.0</version>
   <description>
     This package contains the python bindings PyKDL for the Kinematics and Dynamics
     Library (KDL), distributed by the Orocos Project. 


### PR DESCRIPTION
Currently we have inconsistent version numbers between packages as well as between arden and master.
This PR bumps 2 majors so that we can safely bump each release