### PR TITLE
Change usage of auto_ptr to unique_ptr

### DIFF
--- a/orocos_kdl/src/path.cpp
+++ b/orocos_kdl/src/path.cpp
@@ -59,7 +59,7 @@ using namespace std;
 
 
 Path* Path::Read(istream& is) {
-	// auto_ptr because exception can be thrown !
+	// unique_ptr because exception can be thrown !
 	IOTrace("Path::Read");
 	char storage[64];
 	EatWord(is,"[",storage,sizeof(storage));
@@ -78,7 +78,7 @@ Path* Path::Read(istream& is) {
 		Frame endpos;
 		is >> startpos;
 		is >> endpos;
-		auto_ptr<RotationalInterpolation> orient( RotationalInterpolation::Read(is) );
+		unique_ptr<RotationalInterpolation> orient( RotationalInterpolation::Read(is) );
 		double eqradius;
 		is >> eqradius;
 		EatEnd(is,']');
@@ -99,7 +99,7 @@ Path* Path::Read(istream& is) {
 		is >> R_base_end;
 		is >> alpha;
 		alpha *= deg2rad;
-		auto_ptr<RotationalInterpolation> orient( RotationalInterpolation::Read(is) );
+		unique_ptr<RotationalInterpolation> orient( RotationalInterpolation::Read(is) );
 		is >> eqradius;
 		EatEnd(is,']');
 		IOTracePop();
@@ -119,8 +119,8 @@ Path* Path::Read(istream& is) {
 		is >> radius;
 		double eqradius;
 		is >> eqradius;
-		auto_ptr<RotationalInterpolation> orient( RotationalInterpolation::Read(is) );
-		auto_ptr<Path_RoundedComposite> tr(
+		unique_ptr<RotationalInterpolation> orient( RotationalInterpolation::Read(is) );
+		unique_ptr<Path_RoundedComposite> tr(
 			new Path_RoundedComposite(radius,eqradius,orient.release())
 		);
 		int size;
@@ -139,7 +139,7 @@ Path* Path::Read(istream& is) {
 	} else if (strcmp(storage,"COMPOSITE")==0) {
 		IOTrace("COMPOSITE");
 		int size;
-		auto_ptr<Path_Composite> tr( new Path_Composite() );
+		unique_ptr<Path_Composite> tr( new Path_Composite() );
 		is >> size;
 		int i;
 		for (i=0;i<size;i++) {
@@ -152,7 +152,7 @@ Path* Path::Read(istream& is) {
 	} else if (strcmp(storage,"CYCLIC_CLOSED")==0) {
 		IOTrace("CYCLIC_CLOSED");
 		int times;
-		auto_ptr<Path> tr( Path::Read(is) );
+		unique_ptr<Path> tr( Path::Read(is) );
 		is >> times;
 		EatEnd(is,']');
 		IOTracePop();
@@ -167,4 +167,3 @@ Path* Path::Read(istream& is) {
 
 
 }
-

--- a/orocos_kdl/src/path_composite.cpp
+++ b/orocos_kdl/src/path_composite.cpp
@@ -110,7 +110,7 @@ Twist Path_Composite::Acc(double s,double sd,double sdd) const {
 }
 
 Path* Path_Composite::Clone()  {
-	std::auto_ptr<Path_Composite> comp( new Path_Composite() );
+	std::unique_ptr<Path_Composite> comp( new Path_Composite() );
 	for (unsigned int i = 0; i < dv.size(); ++i) {
 		comp->Add(gv[i].first->Clone(), gv[i].second);
 	}

--- a/orocos_kdl/src/path_roundedcomposite.cpp
+++ b/orocos_kdl/src/path_roundedcomposite.cpp
@@ -104,11 +104,11 @@ void Path_RoundedComposite::Add(const Frame& F_base_point) {
 			if (d >= bcdist)
 				throw Error_MotionPlanning_Not_Feasible(6);
 
-			std::auto_ptr < Path
+			std::unique_ptr < Path
 					> line1(
 							new Path_Line(F_base_start, F_base_via,
 									orient->Clone(), eqradius));
-			std::auto_ptr < Path
+			std::unique_ptr < Path
 					> line2(
 							new Path_Line(F_base_via, F_base_point,
 									orient->Clone(), eqradius));

--- a/orocos_kdl/src/rotational_interpolation.cpp
+++ b/orocos_kdl/src/rotational_interpolation.cpp
@@ -51,7 +51,7 @@ namespace KDL {
 using namespace std;
 
 RotationalInterpolation* RotationalInterpolation::Read(istream& is) {
-	// auto_ptr because exception can be thrown !
+	// unique_ptr because exception can be thrown !
 	IOTrace("RotationalInterpolation::Read");
 	char storage[64];
 	EatWord(is,"[",storage,sizeof(storage));
@@ -83,4 +83,3 @@ RotationalInterpolation* RotationalInterpolation::Read(istream& is) {
 }
 
 }
-

--- a/orocos_kdl/src/trajectory.cpp
+++ b/orocos_kdl/src/trajectory.cpp
@@ -55,15 +55,15 @@ namespace KDL {
 using namespace std;
 
 Trajectory* Trajectory::Read(std::istream& is) {
-	// auto_ptr because exception can be thrown !
+	// unique_ptr because exception can be thrown !
 	IOTrace("Trajectory::Read");
 	char storage[64];
 	EatWord(is,"[",storage,sizeof(storage));
 	Eat(is,'[');
 	if (strcmp(storage,"SEGMENT")==0) {
 		IOTrace("SEGMENT");
-		auto_ptr<Path>      geom(    Path::Read(is)       );
-		auto_ptr<VelocityProfile> motprof( VelocityProfile::Read(is)  );
+		unique_ptr<Path>      geom(    Path::Read(is)       );
+		unique_ptr<VelocityProfile> motprof( VelocityProfile::Read(is)  );
 		EatEnd(is,']');
 		IOTracePop();
 		IOTracePop();
@@ -77,4 +77,3 @@ Trajectory* Trajectory::Read(std::istream& is) {
 
 
 }
-


### PR DESCRIPTION
Auto_ptr has been deprecated and throws warnings when building with clang. Switch to unique_ptr for futureproofing and warning removal.

See https://ci.ros2.org/job/nightly_linux_clang/37/warnings23Result/