### PR TITLE
Add cxx standard to orocos_kdl CMakeLists.txt

### DIFF
--- a/orocos_kdl/CMakeLists.txt
+++ b/orocos_kdl/CMakeLists.txt
@@ -12,6 +12,7 @@ CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
 ###################################################
 
 PROJECT(orocos_kdl)
+set(CMAKE_CXX_STANDARD 11)
 
 SET( KDL_VERSION 1.4.0)
 STRING( REGEX MATCHALL "[0-9]+" KDL_VERSIONS ${KDL_VERSION} )

--- a/orocos_kdl/CMakeLists.txt
+++ b/orocos_kdl/CMakeLists.txt
@@ -12,7 +12,9 @@ CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
 ###################################################
 
 PROJECT(orocos_kdl)
-set(CMAKE_CXX_STANDARD 11)
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
 
 SET( KDL_VERSION 1.4.0)
 STRING( REGEX MATCHALL "[0-9]+" KDL_VERSIONS ${KDL_VERSION} )


### PR DESCRIPTION
I was having issues compiling orocos_kdl as part of the ros2 dashing build. Adding the cxx standard to the CMakeLists.txt fixed the issue.

Related to [#185](https://github.com/orocos/orocos_kinematics_dynamics/issues/185)