### PR TITLE
Update licenses

### DIFF
--- a/orocos_kdl/debian/copyright
+++ b/orocos_kdl/debian/copyright
@@ -8,19 +8,19 @@ Copyright Holder:  Orocos Dev Team
 
 License:
 
-  This program is free software; you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation; either version 2 of the License, or
-  (at your option) any later version.
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
 
-  You should have received a copy of the GNU General Public License
-  along with this package; if not, write to the Free Software
-  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+  You should have received a copy of the GNU Lesser General Public License
+  along with this package; if not, write to the Free Software Foundation,
+  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-On Debian systems, the complete text of the GNU General
-Public License can be found in `/usr/share/common-licenses/GPL'.
+On Debian systems, the complete text of the GNU Lesser General
+Public License can be found in `/usr/share/common-licenses/LGPL'.

--- a/orocos_kdl/package.xml
+++ b/orocos_kdl/package.xml
@@ -3,10 +3,10 @@
   <version>3.3.3</version>
   <description>
     This package contains a recent version of the Kinematics and Dynamics
-    Library (KDL), distributed by the Orocos Project. 
+    Library (KDL), distributed by the Orocos Project.
   </description>
   <maintainer email="jacob@openrobotics.org">Jacob Perron</maintainer>
-  <license>LGPL</license>
+  <license>LGPL-2.1-or-later</license>
   <url>http://wiki.ros.org/orocos_kdl</url>
   <author>Ruben Smits</author>
   <author email="steven@openrobotics.org">Steven! Ragnarök</author>

--- a/orocos_kdl/tests/test-runner.cpp
+++ b/orocos_kdl/tests/test-runner.cpp
@@ -1,21 +1,6 @@
-// Copyright (C) 2007 Klaas Gadeyne <first dot last at gmail dot com>
-//
-// This program is free software; you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation; either version 2 of the License, or
-// (at your option) any later version.
-//
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with this program; if not, write to the Free Software
-// Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
-//
+// Copyright (C) 2007 Klaas Gadeyne
 
-/* Modified from orocos cppunit test code, also published under GPLV2
+/* Modified from orocos cppunit test code
     begin                : Mon January 10 2005
     copyright            : (C) 2005 Peter Soetens
     email                : peter.soetens@mech.kuleuven.ac.be

--- a/python_orocos_kdl/package.xml
+++ b/python_orocos_kdl/package.xml
@@ -6,7 +6,7 @@
     Library (KDL), distributed by the Orocos Project.
   </description>
   <maintainer email="jacob@openrobotics.org">Jacob Perron</maintainer>
-  <license>LGPL</license>
+  <license>LGPL-2.1-or-later</license>
   <url>http://wiki.ros.org/python_orocos_kdl</url>
   <author>Ruben Smits</author>
   <author email="steven@openrobotics.org">Steven! Ragnarök</author>


### PR DESCRIPTION
This is cherry-picking the latest three commits from upstream, resolving the findings of inconsistent license declarations. 

I believe this should be backported to at least Galactic, maybe even all other active distros.
fyi @ralph-lange